### PR TITLE
Address issue #10: minor fix to looping logic in `Bridge` `send_and_receive(...)`)

### DIFF
--- a/pyjavaz/_version.py
+++ b/pyjavaz/_version.py
@@ -1,2 +1,2 @@
-version_info = (1, 2, 4)
+version_info = (1, 2, 5)
 __version__ = ".".join(map(str, version_info))

--- a/pyjavaz/bridge.py
+++ b/pyjavaz/bridge.py
@@ -418,7 +418,7 @@ class Bridge:
                     try:
                         response = self._response_queue.get(timeout=timeout)
                     except Empty:
-                        pass
+                        continue
                     if isinstance(response, Exception):
                         raise response
                     return response


### PR DESCRIPTION
Fix looping in Bridge's send_and_receive so that cases where the response queue times out do not cause a crash (and instead continue looping until a valid response is returned, as intended).

This resolves https://github.com/PyJavaZ/PyJavaZ/issues/10